### PR TITLE
Added file picker dialog filter

### DIFF
--- a/src/submodules/main_panel.rs
+++ b/src/submodules/main_panel.rs
@@ -62,7 +62,7 @@ impl Flasher {
                                 );           
                             });
                             if ui.button(RichText::new(" ").size(15.)).clicked() {
-                                if let Some(path) = rfd::FileDialog::new().pick_file() {
+                                if let Some(path) = rfd::FileDialog::new().add_filter("Firmware files", &["bin","dfu"]).pick_file() {
                                     if !path.display().to_string().contains("dfu") && self.config.int_name == "Pinecil" || 
                                         !path.display().to_string().contains("bin") && self.config.int_name == "Pinecilv2" 
                                     {


### PR DESCRIPTION
Simple change to add a filter when picking a custom firmware file following [`rfd`'s wiki](https://docs.rs/rfd/latest/rfd/). This kept annoying me while troubleshooting issue #/52, as I had to scroll through a few dozen unrelated files. Now only .bin and .dfu files (for V2 and V1 Pinecils respectively) should show up. You can change the description "Firmware files" to whatever you feel like makes more sense.

Tested on Windows 11 and MacOS Sonoma (arm64, not amd64), no issued found.
❗  **Worth it to test on Linux (and MacOS amd64) before pulling.** 

Example of what it looks like on windows:
![image](https://github.com/Spagett1/PineFlash/assets/55107945/35cfdf32-42af-49c7-a16b-1d2019950752)
