### PR TITLE
Add brief mention of WinUSB installation in the main README since it seems it's required on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ Alternatively just run it from your app launcher (unless your on macos).
 
 <img width="17" src="https://cdn.simpleicons.org/Windows/187BC0" /> Windows: Just run pineflash from the start menu.  
 If there is error message like  
-`Cannot open DFU device ... (LIBUSB_ERROR_NOT_SUPPORTED)`
+```
+Cannot open DFU device ... (LIBUSB_ERROR_NOT_SUPPORTED)
+```
 during flash operation, then `WinUSB` drivers should be installed. See [here](https://github.com/libusb/libusb/wiki/Windows#user-content-How_to_use_libusb_on_Windows) for more details.
 
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Alternatively just run it from your app launcher (unless your on macos).
      `pineflash`
 
 <img width="17" src="https://cdn.simpleicons.org/Windows/187BC0" /> Windows: Just run pineflash from the start menu.
+If there is error message like `Cannot open DFU device ... (LIBUSB_ERROR_NOT_SUPPORTED)` during flash operation, then `WinUSB` drivers should be installed. See [here](https://github.com/libusb/libusb/wiki/Windows#user-content-How_to_use_libusb_on_Windows) for more details.
 
 
 ## Boot Logo Art

--- a/README.md
+++ b/README.md
@@ -277,8 +277,10 @@ Alternatively just run it from your app launcher (unless your on macos).
 
      `pineflash`
 
-<img width="17" src="https://cdn.simpleicons.org/Windows/187BC0" /> Windows: Just run pineflash from the start menu.
-If there is error message like `Cannot open DFU device ... (LIBUSB_ERROR_NOT_SUPPORTED)` during flash operation, then `WinUSB` drivers should be installed. See [here](https://github.com/libusb/libusb/wiki/Windows#user-content-How_to_use_libusb_on_Windows) for more details.
+<img width="17" src="https://cdn.simpleicons.org/Windows/187BC0" /> Windows: Just run pineflash from the start menu.  
+If there is error message like  
+`Cannot open DFU device ... (LIBUSB_ERROR_NOT_SUPPORTED)`
+during flash operation, then `WinUSB` drivers should be installed. See [here](https://github.com/libusb/libusb/wiki/Windows#user-content-How_to_use_libusb_on_Windows) for more details.
 
 
 ## Boot Logo Art


### PR DESCRIPTION
Hello.
Disclaimer: I don't have Pinecil nor I haven't had a chance to use `PineFlash` on Windows.

Recently there was the issue report in IronOS project. It has nothing to do with `PineFlash` project directly. However [user had minor problem with flashing](https://github.com/Ralim/IronOS/discussions/1815#discussioncomment-7044412) `Pinecil` on `Windows` using `PineFlash`. I had to dig some information and it seems that `PineFlash` uses `dfu-util` to flash, but `dfu-util` itself requires `WinUSB` drivers installed to have write access to `usb` devices on `Windows` through `libusb`. At least, after suggestion to install `WinUSB`, [it worked for user](https://github.com/Ralim/IronOS/discussions/1815#discussioncomment-7047437): installing `WinUSB` did make `PineFlash` to flash the `Pinecil`. Plus, I looked through docs in this repo but I didn't manage to find any mention of this.

Hence, this tiny patch adds brief mention of the additional step on `Windows`.