### PR TITLE
Fix install on Mac

### DIFF
--- a/generic_unix_install.sh
+++ b/generic_unix_install.sh
@@ -8,8 +8,8 @@ fi
 cargo build --release
 
 if [ "$(uname)" == "Darwin" ]; then
-  curl -L "https://github.com/pine64/blisp/releases/download/v0.0.4/blisp-macos64-v0.0.4.zip" -o "blisp-macos64-v0.0.4.zip"
-  unzip "blisp-macos64-v0.0.4.zip"
+  curl -L "https://github.com/pine64/blisp/releases/download/v0.0.4/blisp-apple-x86_64-v0.0.4.zip" -o "blisp-apple-x86_64-v0.0.4.zip"
+  unzip "blisp-apple-x86_64-v0.0.4.zip"
   chmod +x ./blisp
   $root cp ./blisp /usr/local/bin/blisp
   $root chmod +x /usr/local/bin/blisp


### PR DESCRIPTION
Hello, I wanted to update the app and flash my Pinecil today but it failed on the unzip step. I noticed that the asset's filename changed in the blisp repository.
After this change I was able to install PineFlash correctly. I tested on a Mac M1.

Reference: https://github.com/pine64/blisp/releases/tag/v0.0.4