### PR TITLE
Add check for cargo before trying to build with cargo

### DIFF
--- a/generic_unix_install.sh
+++ b/generic_unix_install.sh
@@ -5,6 +5,12 @@ else
   root=sudo
 fi
 
+# Ensure cargo is installed before trying to proceed
+if ! command -v cargo > /dev/null 2>&1; then
+    echo "cargo command is not installed. Cannot proceed. Please ensure cargo is installed and on the PATH"
+    exit 1
+fi
+
 cargo build --release
 
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Without checking for `cargo`, the installer script gets to the `blisp` portion and then fails. Checking and warning the user that `cargo` is missing causes less confusion