### PR TITLE
fix: panic on unhandled error rather than only printing it

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -529,6 +529,6 @@ fn main() {
         }),
         ) {
         Ok(_) => (),
-        Err(error) => println!("A massive error occured, not sure whats goin on here: \n {}", error),
+        Err(error) => panic!("A massive error occured, not sure whats goin on here: \n {}"),
     }
 }


### PR DESCRIPTION
Previously, pineflash would 'handle' all errors by printing them, annoyingly eating the stack trace. This is a trivial substitution of `panic!` in place of `println!` – pineflash still prints the error message, but now with the stack trace included, assuming `RUST_BACKTRACE` is set.

Related-to: gh-57