### PR TITLE
fix: main.rs, log error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -529,6 +529,6 @@ fn main() {
         }),
         ) {
         Ok(_) => (),
-        Err(error) => panic!("A massive error occured, not sure whats goin on here: \n {}"),
+        Err(error) => panic!("A massive error occured, not sure whats goin on here: \n {}", error),
     }
 }


### PR DESCRIPTION
The error had format w/o argument. The `error` variable was unused.