### PR TITLE
ci: add github ci intergration to ensure PRs build successfully

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,33 @@
+name: Cargo Tests
+
+on:
+  - push
+  - pull_request
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+          - ubuntu-latest
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install ${{ matrix.toolchain}} Rust toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - if: matrix.os == 'ubuntu-latest'
+        name: Install Linux build dependencies
+        run: sudo apt-get -yq install libgtk-3-dev libudev-dev
+      - name: Run cargo tests
+        run: cargo test --verbose


### PR DESCRIPTION
This adds GitHub Actions integration to automatically build (and run tests, should they be added in the future) on Windows, MacOS, and Linux.

This will (hopefully) prevent issues like gh-87 (introduced by gh-83) from recurring in the future.

Related-to: gh-83, gh-86, gh-87